### PR TITLE
Add documentation archive to plugin release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,7 +9,7 @@ before:
     - go test ./...
     # As part of the release doc files are included as a separate deliverable for
     # consumption by Packer.io. To include a separate docs.zip uncomment the following command.
-    #- make ci-release-docs
+    - make ci-release-docs
     # Check plugin compatibility with required version of the Packer SDK
     - make plugin-check
 builds:
@@ -73,8 +73,8 @@ release:
   # draft: true
   # As part of the release doc files are included as a separate deliverable for consumption by Packer.io.
   # To include a separate docs.zip uncomment the extra_files config and the docs.zip command hook above.
-  #extra_files:
-  #- glob: ./docs.zip
+  extra_files:
+  - glob: ./docs.zip
 
 changelog:
   skip: true

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -22,7 +22,6 @@ install-packer-sdc: ## Install packer sofware development command
 	@go install github.com/hashicorp/packer-plugin-sdk/cmd/packer-sdc@${HASHICORP_PACKER_PLUGIN_SDK_VERSION}
 
 ci-release-docs: install-packer-sdc
-	@packer-sdc renderdocs -src docs -partials docs-partials/ -dst docs/
 	@/bin/sh -c "[ -d docs ] && zip -r docs.zip docs/"
 
 plugin-check: install-packer-sdc build


### PR DESCRIPTION
This change updates the main plugin makefile to generate the docs.zip
file needed by Packer.io for remote documentation ingestion, at release.

The accompanying .goreleaser file has been updated to published the
generated zip.

@ivoronin apologies I might've confused the situation more with my change to the scaffolding project. I created this PR to help. 