### PR TITLE
add temporary_key_pair_name option to usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ For the full list of available features for this plugin see [documentation](http
 Packer 1.7.3 or later is required.
 
 ## Usage example
+
 ```hcl
 packer {
   required_plugins {
@@ -17,13 +18,19 @@ packer {
   }
 }
 
+variables {
+  temporary_key_pair_name = "my_temp_key"
+}
+
 data "sshkey" "install" {
+  name = var.temporary_key_pair_name
 }
 
 source "qemu" "install" {
   ssh_username              = "root"
   ssh_private_key_file      = data.sshkey.install.private_key_path
   ssh_clear_authorized_keys = true
+  temporary_key_pair_name   = var.temporary_key_pair_name
   http_content = {
     "/preseed.cfg" = templatefile("preseed.cfg.pkrtpl", {
         "ssh_public_key" : data.sshkey.install.public_key

--- a/docs/datasources/sshkey.mdx
+++ b/docs/datasources/sshkey.mdx
@@ -34,13 +34,19 @@ packer {
   }
 }
 
+variables {
+  temporary_key_pair_name = "my_temp_key"
+}
+
 data "sshkey" "install" {
+  name = var.temporary_key_pair_name
 }
 
 source "qemu" "install" {
   ssh_username              = "root"
   ssh_private_key_file      = data.sshkey.install.private_key_path
   ssh_clear_authorized_keys = true
+  temporary_key_pair_name   = var.temporary_key_pair_name
   http_content = {
     "/preseed.cfg" = templatefile("preseed.cfg.pkrtpl", {
         "ssh_public_key" : data.sshkey.install.public_key


### PR DESCRIPTION
Hello!

In order for the packer to clean up the SSH keys after build you need to add the `temporary_key_pair_name` option to `source` block. Otherwise, the temporary key will remain in the image.

See Packer SDK sources: https://github.com/hashicorp/packer-plugin-sdk/blob/7e45483efa78142ca694da2667ad69867502c262/multistep/commonsteps/step_cleanup_temp_keys.go#L30