### PR TITLE
Register plug-in as Packer integration

### DIFF
--- a/.github/workflows/ensure-docs-compiled.yaml
+++ b/.github/workflows/ensure-docs-compiled.yaml
@@ -9,14 +9,14 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-go@v4
       - shell: bash
-        run: make build-docs
+        run: make generate
       - shell: bash
         run: |
           if [[ -z "$(git status -s)" ]]; then
             echo "OK"
           else
             echo "Docs have been updated, but the compiled docs have not been committed."
-            echo "Run 'make build-docs', and commit the result to resolve this error."
+            echo "Run 'make generate', and commit the result to resolve this error."
             exit 1
           fi
 

--- a/.github/workflows/notify-integration-release-via-manual.yaml
+++ b/.github/workflows/notify-integration-release-via-manual.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Notify Release
         uses: ./integration-release-action
         with:
-          integration_identifier: 'packer/hashicorp/sshkey'
+          integration_identifier: 'packer/BrandonRomano/sshkey'
           release_version: ${{ github.event.inputs.version }}
           release_sha: ${{ github.event.inputs.branch }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/notify-integration-release-via-manual.yaml
+++ b/.github/workflows/notify-integration-release-via-manual.yaml
@@ -1,10 +1,12 @@
+# Manual release workflow is used for deploying documentation updates
+# on the specified branch without making an official plugin release. 
 name: Notify Integration Release (Manual)
 on:
   workflow_dispatch:
     inputs:
       version:
         description: "The release version (semver)"
-        default: 0.0.1
+        default: 1.0.0
         required: false
       branch:
         description: "A branch or SHA"
@@ -15,32 +17,34 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repo
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
           ref: ${{ github.event.inputs.branch }}
       # Ensure that Docs are Compiled
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       - shell: bash
-        run: make build-docs
+        run: make generate
       - shell: bash
         run: |
           if [[ -z "$(git status -s)" ]]; then
             echo "OK"
           else
             echo "Docs have been updated, but the compiled docs have not been committed."
-            echo "Run 'make build-docs', and commit the result to resolve this error."
+            echo "Run 'make generate', and commit the result to resolve this error."
             exit 1
           fi
       # Perform the Release
       - name: Checkout integration-release-action
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
           repository: hashicorp/integration-release-action
           path: ./integration-release-action
       - name: Notify Release
         uses: ./integration-release-action
         with:
-          integration_identifier: 'packer/BrandonRomano/sshkey'
+          # The integration identifier will be used by the Packer team to register the integration
+          # the expected format is packer/<GitHub Org Name>/<plugin-name>
+          integration_identifier: "packer/hashicorp/scaffolding"
           release_version: ${{ github.event.inputs.version }}
           release_sha: ${{ github.event.inputs.branch }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/notify-integration-release-via-tag.yaml
+++ b/.github/workflows/notify-integration-release-via-tag.yaml
@@ -3,31 +3,43 @@ on:
   push:
     tags:
       - '*.*.*'   # Proper releases
-      - '*.*.*-*' # Pre releases
 jobs:
+  strip-version:
+    runs-on: ubuntu-latest
+    outputs:
+      packer-version: ${{ steps.strip.outputs.packer-version }}
+    steps:
+      - name: Strip leading v from version tag
+        id: strip
+        env:
+          REF: ${{ github.ref_name }}
+        run: |
+          echo "packer-version=$(echo "$REF" | sed -E 's/v?([0-9]+\.[0-9]+\.[0-9]+)/\1/')" >> "$GITHUB_OUTPUT"
   notify-release:
+    needs:
+      - strip-version
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repo
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
           ref: ${{ github.ref }}
       # Ensure that Docs are Compiled
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       - shell: bash
-        run: make build-docs
+        run: make generate
       - shell: bash
         run: |
           if [[ -z "$(git status -s)" ]]; then
             echo "OK"
           else
             echo "Docs have been updated, but the compiled docs have not been committed."
-            echo "Run 'make build-docs', and commit the result to resolve this error."
+            echo "Run 'make generate', and commit the result to resolve this error."
             exit 1
           fi
       # Perform the Release
       - name: Checkout integration-release-action
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
           repository: hashicorp/integration-release-action
           path: ./integration-release-action

--- a/.github/workflows/notify-integration-release-via-tag.yaml
+++ b/.github/workflows/notify-integration-release-via-tag.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Notify Release
         uses: ./integration-release-action
         with:
-          integration_identifier: 'packer/hashicorp/sshkey'
+          integration_identifier: 'packer/ivoronin/sshkey'
           release_version: ${{ github.ref_name }}
           release_sha: ${{ github.ref }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.web-docs/metadata.hcl
+++ b/.web-docs/metadata.hcl
@@ -3,7 +3,7 @@
 integration {
   name = "SSH Key"
   description = "The SSHkey plugin can be used for generating SSH keys for configuring private key authentication."
-  identifier = "packer/hashicorp/sshkey"
+  identifier = "packer/ivoronin/sshkey"
   component {
     type = "data-source"
     name = "SSH Key"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -36,5 +36,5 @@ generate: install-packer-sdc
 build-docs: install-packer-sdc
 	@if [ -d ".docs" ]; then rm -r ".docs"; fi
 	@packer-sdc renderdocs -src "docs" -partials docs-partials/ -dst ".docs/"
-	@./.web-docs/scripts/compile-to-webdocs.sh "." ".docs" ".web-docs" "hashicorp"
+	@./.web-docs/scripts/compile-to-webdocs.sh "." ".docs" ".web-docs" "ivoronin"
 	@rm -r ".docs"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -21,9 +21,6 @@ test:
 install-packer-sdc: ## Install packer sofware development command
 	@go install github.com/hashicorp/packer-plugin-sdk/cmd/packer-sdc@${HASHICORP_PACKER_PLUGIN_SDK_VERSION}
 
-ci-release-docs: install-packer-sdc
-	@/bin/sh -c "[ -d docs ] && zip -r docs.zip docs/"
-
 plugin-check: install-packer-sdc build
 	@packer-sdc plugin-check ${BINARY}
 
@@ -32,8 +29,6 @@ testacc: dev
 
 generate: install-packer-sdc
 	@go generate ./...
-
-build-docs: install-packer-sdc
 	@if [ -d ".docs" ]; then rm -r ".docs"; fi
 	@packer-sdc renderdocs -src "docs" -partials docs-partials/ -dst ".docs/"
 	@./.web-docs/scripts/compile-to-webdocs.sh "." ".docs" ".web-docs" "ivoronin"


### PR DESCRIPTION
:wave: fellow Packer maintainer working on migrating your plugin to the Packer integration framework.

This change takes the necessary steps to register this plugin as an official Packer integration.
Integrations can be found on the Packer integration portal at https://developer.hashicorp.com/packer/integrations.

---

The pull-request consists of the following changes:

- Adds controlling, metadata file, `metadata.hcl` for registering the plug-in and it components as integrations.
Details on the contents, along with a description of the attributes, can be found at https://github.com/hashicorp/integration-template.
- Adds the GitHub action workflows for triggering manual and automatic integration updates.
- Restructures the plug-in documentation to match the expected format of the integration framework.
- Adds a `.web-docs` directory for serving the fully render documentation as the integration docs.
- Adds the build-docs make target `make build-docs` for syncing changes to the `docs` directory to the `.web-docs` directory.

Changes to the integration docs can be made at plugin release via the `notify-integration-release-via-tag` workflow or
manually by running the `notify-integration-release-via-manual` workflow.

Details on how the Integration framework pipeline works can be found at https://github.com/hashicorp/packer/pull/12702

### TODOs
- [x] Open pull-request against external plugin.
- [ ] Update integration description [`.web-docs/metadata.hcl`](.web-docs/metadata.hcl).
- [ ] Packer team open internal pull-request to enable integration.
- [ ] Review plugin integration on Packer integration portal .... Iterate
